### PR TITLE
[GH #55357] Fixed a bad indentation in SriovNetworkNodePolicy example

### DIFF
--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -33,7 +33,7 @@ spec:
     netFilter: "<filter_string>" <14>
   deviceType: <device_type> <15>
   isRdma: false <16>
-    linkType: <link_type> <17>
+  linkType: <link_type> <17>
   eSwitchMode: "switchdev" <18>
 ----
 <1> The name for the custom resource object.


### PR DESCRIPTION
Fixed a bad indentation in SriovNetworkNodePolicy example

Version(s):
4.12

Issue: https://github.com/openshift/openshift-docs/issues/55357

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.


